### PR TITLE
Improve coherence of BaseBenchmark and BaseBuilder

### DIFF
--- a/benchmon/benchmark/base.py
+++ b/benchmon/benchmark/base.py
@@ -11,6 +11,7 @@ from typing import ClassVar, Coroutine, Iterable, Optional, Set, TYPE_CHECKING, 
 from coloredlogs import ColoredFormatter
 
 from .. import Context, ContextReadable
+from ..configs.containers import PrivilegeConfig
 from ..exceptions import BenchNotFoundError
 from ..utils.privilege import drop_privilege
 
@@ -19,7 +20,7 @@ if TYPE_CHECKING:
 
     # because of circular import
     from .constraints import BaseConstraint
-    from ..configs.containers import BenchConfig, PrivilegeConfig
+    from ..configs.containers import BenchConfig
     from ..monitors import BaseMonitor
     from ..monitors.pipelines import BasePipeline
 
@@ -131,7 +132,6 @@ class BaseBenchmark(ContextReadable, metaclass=ABCMeta):
         # setup for loggers
         logger = logging.getLogger(self._identifier)
 
-        from ..configs.containers import PrivilegeConfig
         privilege_cfg = PrivilegeConfig.of(self._context_variable).result
 
         with drop_privilege(privilege_cfg.user, privilege_cfg.group):

--- a/benchmon/benchmark/base.py
+++ b/benchmon/benchmark/base.py
@@ -86,8 +86,7 @@ class BaseBenchmark(ContextReadable, metaclass=ABCMeta):
                 constraints: Tuple[BaseConstraint, ...],
                 monitors: Tuple[_MON_T, ...],
                 pipeline: BasePipeline,
-                privilege_config: PrivilegeConfig,
-                logger_level=logging.INFO) -> BaseBenchmark:
+                privilege_config: PrivilegeConfig) -> BaseBenchmark:
         obj: BaseBenchmark = super().__new__(cls)
 
         obj._bench_config = bench_config
@@ -100,18 +99,6 @@ class BaseBenchmark(ContextReadable, metaclass=ABCMeta):
 
         # setup for logger
         obj._log_path = bench_config.workspace / 'logs' / f'{bench_config.identifier}.log'
-
-        logger = logging.getLogger(bench_config.identifier)
-        logger.setLevel(logger_level)
-
-        # noinspection PyProtectedMember
-        obj._context_variable._assign(cls, obj)
-        # noinspection PyProtectedMember
-        obj._context_variable._assign(logging.Logger, logger)
-        # noinspection PyProtectedMember
-        obj._context_variable._assign(type(pipeline), pipeline)
-        # noinspection PyProtectedMember
-        obj._context_variable._assign(type(privilege_config), privilege_config)
 
         return obj
 

--- a/benchmon/benchmark/drivers/engines/cgroup.py
+++ b/benchmon/benchmark/drivers/engines/cgroup.py
@@ -33,7 +33,8 @@ class CGroupEngine(BaseEngine):
         if constraint is not None:
             if constraint.cgroup is None:
                 raise InitRequiredError(
-                    f'Initialize the {type(CGroupConstraint).__name__} before running the benchmark.')
+                        f'Initialize the {type(constraint).__name__} before running the benchmark.'
+                )
 
             kwargs['preexec_fn'] = constraint.cgroup.add_current_process
 

--- a/benchmon/benchmark/drivers/engines/cgroup.py
+++ b/benchmon/benchmark/drivers/engines/cgroup.py
@@ -7,6 +7,7 @@ from typing import TYPE_CHECKING
 
 from .base import BaseEngine
 from ...constraints import CGroupConstraint
+from ....configs.containers import PrivilegeConfig
 from ....exceptions import InitRequiredError
 from ....utils.privilege import drop_privilege
 
@@ -36,7 +37,6 @@ class CGroupEngine(BaseEngine):
 
             kwargs['preexec_fn'] = constraint.cgroup.add_current_process
 
-        from ....configs.containers import PrivilegeConfig
         privilege_config = PrivilegeConfig.of(context).execute
 
         with drop_privilege(privilege_config.user, privilege_config.group):

--- a/benchmon/benchmark/drivers/engines/numactl.py
+++ b/benchmon/benchmark/drivers/engines/numactl.py
@@ -7,6 +7,7 @@ from typing import TYPE_CHECKING
 
 from .base import BaseEngine
 from ...constraints import CGroupConstraint
+from ....configs.containers import PrivilegeConfig
 from ....utils.privilege import drop_privilege
 
 if TYPE_CHECKING:
@@ -25,7 +26,6 @@ class NumaCtlEngine(BaseEngine):
 
     @classmethod
     async def launch(cls, context: Context, *cmd: str, **kwargs) -> asyncio.subprocess.Process:
-        from ....configs.containers import PrivilegeConfig
         privilege_config = PrivilegeConfig.of(context).execute
 
         constraint = CGroupConstraint.of(context)

--- a/benchmon/benchmark/launchable.py
+++ b/benchmon/benchmark/launchable.py
@@ -43,20 +43,15 @@ class LaunchableBenchmark(BaseBenchmark):
                 constraints: Tuple[BaseConstraint, ...],
                 monitors: Tuple[BaseMonitor[MonitorData], ...],
                 pipeline: BasePipeline,
-                privilege_config: PrivilegeConfig,
-                logger_level=logging.INFO) -> LaunchableBenchmark:
+                privilege_config: PrivilegeConfig) -> LaunchableBenchmark:
         obj: LaunchableBenchmark = super().__new__(
                 cls,
                 launchable_config,
                 constraints,
                 monitors,
                 pipeline,
-                privilege_config,
-                logger_level
+                privilege_config
         )
-
-        # noinspection PyProtectedMember
-        obj._context_variable._assign(BaseEngine, CGroupEngine)
 
         obj._bench_driver = gen_driver(launchable_config.name)
 
@@ -121,8 +116,15 @@ class LaunchableBenchmark(BaseBenchmark):
                      logger_level: int = logging.INFO) -> None:
             super().__init__(launchable_config, privilege_config, logger_level)
 
-        def _init_pipeline(self) -> DefaultPipeline:
+        @classmethod
+        def _init_pipeline(cls) -> DefaultPipeline:
             return DefaultPipeline()
+
+        def _init_context_var(self, benchmark: LaunchableBenchmark, logger_level: int) -> None:
+            super()._init_context_var(benchmark, logger_level)
+
+            # noinspection PyProtectedMember
+            benchmark._context_variable._assign(BaseEngine, CGroupEngine)
 
         def _finalize(self) -> LaunchableBenchmark:
             return LaunchableBenchmark.__new__(
@@ -131,6 +133,5 @@ class LaunchableBenchmark(BaseBenchmark):
                     tuple(self._constraints.values()),
                     tuple(self._monitors),
                     self._pipeline,
-                    self._privilege_config,
-                    self._logger_level
+                    self._privilege_config
             )

--- a/benchmon/configs/containers/__init__.py
+++ b/benchmon/configs/containers/__init__.py
@@ -12,7 +12,7 @@
 """
 
 from .base import BaseConfig, HandlerConfig, MonitorConfig
+from .privilege import Privilege, PrivilegeConfig
 from .bench import BenchConfig, LaunchableConfig
 from .perf import PerfConfig, PerfEvent
-from .privilege import Privilege, PrivilegeConfig
 from .rabbit_mq import RabbitMQConfig


### PR DESCRIPTION
- Separate instantiation and initialization of `ContextVariable`.
- Lower correlations by reducing the number of `BaseBenchmark` parameters.