### PR TITLE
add a remote launchable ssh benchmark class

### DIFF
--- a/benchmon/benchmark/__init__.py
+++ b/benchmon/benchmark/__init__.py
@@ -54,5 +54,6 @@
 from .base import BaseBenchmark
 from .base_builder import BaseBuilder
 from .launchable import LaunchableBenchmark
+from .ssh_remote import SSHBenchmark
 
 BaseBenchmark.register_nickname(LaunchableBenchmark)

--- a/benchmon/benchmark/ssh_remote.py
+++ b/benchmon/benchmark/ssh_remote.py
@@ -1,0 +1,146 @@
+# coding: UTF-8
+
+from __future__ import annotations
+
+import logging
+import signal
+from abc import ABC
+from typing import Optional, TYPE_CHECKING, Tuple, Type, TypeVar
+
+import asyncssh
+from asyncssh import SSHClientConnection, SSHClientConnectionOptions, SSHClientProcess
+
+from .base import BaseBenchmark
+from .base_builder import BaseBuilder
+from ..configs.containers import SSHConfig
+from ..monitors.pipelines import DefaultPipeline
+
+if TYPE_CHECKING:
+    from .constraints import BaseConstraint
+    from .. import Context
+    from ..configs.containers import PrivilegeConfig
+    from ..monitors import BaseMonitor
+    from ..monitors.pipelines import BasePipeline
+
+    _CST_T = TypeVar('_CST_T', bound=BaseConstraint)
+    _MON_T = TypeVar('_MON_T', bound=BaseMonitor)
+
+_CFG_T = TypeVar('_CFG_T', bound=SSHConfig)
+
+
+class SSHBenchmark(BaseBenchmark[_CFG_T], ABC):
+    __slots__ = ('_ssh_conn', '_tunnel_conn')
+
+    _tunnel_conn: Optional[SSHClientConnection]
+    _ssh_conn: SSHClientConnection
+    _ssh_proc: Optional[SSHClientProcess]
+
+    @classmethod
+    def of(cls, context: Context) -> Optional[SSHBenchmark]:
+        # noinspection PyProtectedMember
+        for c, v in context._variable_dict.items():
+            if issubclass(c, cls):
+                return v
+
+        return None
+
+    def __new__(cls: Type[SSHBenchmark],
+                ssh_config: _CFG_T,
+                constraints: Tuple[_CST_T, ...],
+                monitors: Tuple[_MON_T, ...],
+                pipeline: BasePipeline,
+                privilege_config: PrivilegeConfig) -> SSHBenchmark:
+        # noinspection PyTypeChecker
+        obj: SSHBenchmark = super().__new__(cls, ssh_config, constraints, monitors, pipeline, privilege_config)
+
+        if obj._bench_config.tunnel is not None:
+            options = obj._bench_config.tunnel
+            obj._tunnel_conn = await asyncssh.connect(
+                    options['host'],
+                    port=options.get('port'),
+                    local_addr=options.get('local_addr'),
+                    options=SSHClientConnectionOptions(**options.get('options'))
+            )
+        else:
+            obj._tunnel_conn = None
+
+        obj._ssh_conn = await asyncssh.connect(
+                obj._bench_config.host,
+                port=obj._bench_config.port,
+                tunnel=obj._tunnel_conn,
+                local_addr=obj._bench_config.local_addr,
+                options=SSHClientConnectionOptions(**obj._bench_config.options)
+        )
+
+        obj._ssh_proc = None
+
+        return obj
+
+    def __del__(self) -> None:
+        if self.is_running:
+            self._ssh_proc.kill()
+            self._ssh_proc.close()
+
+        self._ssh_conn.close()
+
+        if self._tunnel_conn:
+            self._tunnel_conn.close()
+
+    def pause(self) -> None:
+        super().pause()
+
+        self._ssh_proc.send_signal(signal.SIGSTOP)
+
+    def resume(self) -> None:
+        super().resume()
+
+        self._ssh_proc.send_signal(signal.SIGCONT)
+
+    async def join(self) -> None:
+        await super().join()
+
+        self._ssh_proc.wait()
+
+    async def _start(self, context: Context) -> None:
+        pass
+        # TODO
+
+    async def kill(self) -> None:
+        await super().kill()
+
+        logger = logging.getLogger(self._identifier)
+
+        if self.is_running:
+            self._ssh_proc.kill()
+            self._ssh_proc.close()
+        else:
+            logger.debug('Process already killed.')
+
+    @property
+    def is_running(self) -> bool:
+        return self._ssh_proc.returncode is None
+
+    class Builder(BaseBuilder['SSHBenchmark']):
+        __slots__ = ('_bench_config',)
+
+        _bench_config: SSHConfig
+
+        def __init__(self,
+                     ssh_config: SSHConfig,
+                     privilege_config: PrivilegeConfig,
+                     logger_level: int = logging.INFO) -> None:
+            super().__init__(ssh_config, privilege_config, logger_level)
+
+        @classmethod
+        def _init_pipeline(cls) -> DefaultPipeline:
+            return DefaultPipeline()
+
+        def _finalize(self) -> SSHBenchmark:
+            return SSHBenchmark.__new__(
+                    SSHBenchmark,
+                    self._bench_config,
+                    tuple(self._constraints.values()),
+                    tuple(self._monitors),
+                    self._pipeline,
+                    self._privilege_config
+            )

--- a/benchmon/benchmark/ssh_remote.py
+++ b/benchmon/benchmark/ssh_remote.py
@@ -102,8 +102,7 @@ class SSHBenchmark(BaseBenchmark[_CFG_T], ABC):
         self._ssh_proc.wait()
 
     async def _start(self, context: Context) -> None:
-        pass
-        # TODO
+        self._ssh_proc = await self._ssh_conn.create_process(self._bench_config.command)
 
     async def kill(self) -> None:
         await super().kill()

--- a/benchmon/benchmark/ssh_remote.py
+++ b/benchmon/benchmark/ssh_remote.py
@@ -89,17 +89,17 @@ class SSHBenchmark(BaseBenchmark[_CFG_T], ABC):
     def pause(self) -> None:
         super().pause()
 
-        self._ssh_proc.send_signal(signal.SIGSTOP)
+        self._ssh_proc.channel.send_signal(signal.SIGSTOP)
 
     def resume(self) -> None:
         super().resume()
 
-        self._ssh_proc.send_signal(signal.SIGCONT)
+        self._ssh_proc.channel.send_signal(signal.SIGCONT)
 
     async def join(self) -> None:
         await super().join()
 
-        self._ssh_proc.wait()
+        await self._ssh_proc.wait()
 
     async def _start(self, context: Context) -> None:
         self._ssh_proc = await self._ssh_conn.create_process(self._bench_config.command)

--- a/benchmon/configs/containers/__init__.py
+++ b/benchmon/configs/containers/__init__.py
@@ -13,6 +13,6 @@
 
 from .base import BaseConfig, HandlerConfig, MonitorConfig
 from .privilege import Privilege, PrivilegeConfig
-from .bench import BenchConfig, LaunchableConfig
+from .bench import BenchConfig, LaunchableConfig, SSHConfig
 from .perf import PerfConfig, PerfEvent
 from .rabbit_mq import RabbitMQConfig

--- a/benchmon/configs/containers/bench.py
+++ b/benchmon/configs/containers/bench.py
@@ -51,6 +51,7 @@ class LaunchableConfig(BenchConfig):
 @dataclass(frozen=True)
 class SSHConfig(BenchConfig):
     host: str
+    command: str
     port: Optional[int]
     tunnel: Optional[Dict[str, Any]]
     local_addr: Optional[Tuple[str, int]]

--- a/benchmon/configs/containers/bench.py
+++ b/benchmon/configs/containers/bench.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import logging
 from abc import abstractmethod
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Tuple, TypeVar
+from typing import Any, Dict, Optional, TYPE_CHECKING, Tuple, TypeVar
 
 from .base import BaseConfig
 
@@ -41,7 +41,22 @@ class LaunchableConfig(BenchConfig):
 
     name: str
 
-    def generate_builder(self, privilege_config: PrivilegeConfig,
+    def generate_builder(self,
+                         privilege_config: PrivilegeConfig,
                          logger_level: int = logging.INFO) -> LaunchableBenchmark.Builder:
         from ...benchmark import LaunchableBenchmark
         return LaunchableBenchmark.Builder(self, privilege_config, logger_level)
+
+
+@dataclass(frozen=True)
+class SSHConfig(BenchConfig):
+    host: str
+    port: Optional[int]
+    tunnel: Optional[Dict[str, Any]]
+    local_addr: Optional[Tuple[str, int]]
+    options: Optional[Dict[str, Any]]
+
+    def generate_builder(self,
+                         privilege_config: PrivilegeConfig,
+                         logger_level: int = logging.INFO) -> BaseBuilder:
+        pass

--- a/benchmon/configs/parsers/benchmark/__init__.py
+++ b/benchmon/configs/parsers/benchmark/__init__.py
@@ -30,5 +30,7 @@
 
 from .base import BaseBenchParser
 from .launchable import LaunchableParser
+from .ssh_remote import SSHParser
 
 BaseBenchParser.register_parser(LaunchableParser)
+BaseBenchParser.register_parser(SSHParser)

--- a/benchmon/configs/parsers/benchmark/ssh_remote.py
+++ b/benchmon/configs/parsers/benchmark/ssh_remote.py
@@ -1,0 +1,66 @@
+# coding: UTF-8
+
+from __future__ import annotations
+
+from collections import defaultdict
+from typing import ClassVar, DefaultDict, Iterable, List, TYPE_CHECKING, Tuple
+
+from ordered_set import OrderedSet
+
+from .base import BaseBenchParser
+from ...containers import SSHConfig
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from .base import BenchJson
+
+
+class SSHParser(BaseBenchParser[SSHConfig]):
+    _PARSABLE_TYPES: ClassVar[Tuple[str, ...]] = ('ssh',)
+
+    @classmethod
+    def parse(cls, configs: Tuple[BenchJson, ...], workspace: Path) -> Iterable[SSHConfig]:
+        cfg_dict: DefaultDict[str, List[BenchJson]] = defaultdict(list)
+        for cfg in map(cls._deduct_config, configs):
+            cfg_dict[cfg['name']].append(cfg)
+            cfg['identifier'] = cfg['name']
+
+        entries: OrderedSet[str] = OrderedSet(cls._entry_prefix_map.keys())
+        for benches in cfg_dict.values():
+            cls._gen_identifier(tuple(benches), entries)
+
+            same_count: int = 0
+            sorted_cfg = sorted(benches, key=lambda x: x['identifier'])
+            for idx, curr in enumerate(sorted_cfg[1:]):
+                prev = sorted_cfg[idx]
+
+                if prev['identifier'] == curr['identifier']:
+                    same_count += 1
+                    prev['identifier'] += f'_{same_count}'
+                elif same_count != 0:
+                    prev['identifier'] += f'_{same_count + 1}'
+                    same_count = 0
+                else:
+                    same_count = 0
+
+            if same_count != 0:
+                sorted_cfg[-1]['identifier'] += f'_{same_count + 1}'
+
+        max_id_len = max(map(lambda x: len(x['identifier']), configs))
+
+        for config in configs:
+            yield SSHConfig(
+                    config['num_of_threads'],
+                    config['type'],
+                    cls._gen_constraints(config),
+                    config['identifier'],
+                    workspace,
+                    max_id_len,
+                    config['host'],
+                    config['command'],
+                    config.get('port'),
+                    config.get('tunnel'),
+                    config.get('local_addr'),
+                    config.get('options')
+            )

--- a/hybrid_iso/config.template.json
+++ b/hybrid_iso/config.template.json
@@ -34,16 +34,15 @@
 			"cpu_freq": 2.1
 		},
 		{
-			"ssh": {
-				"host": "bc2",
+			"host": "bc2",
+			"options": {
 				"username": "dcslab",
-				"password": "dcs%%*#",
-				"working_directory": "/home/dcslab/bhyoo/projects/dynamic_ab",
-				"command": ". ./venv/bin/activate; ./dab.py i script5.json"
+				"client_host_keysign": true
 			},
+			"command": "/home/dcslab/bhyoo/projects/dynamic_ab/venv/bin/python /home/dcslab/bhyoo/projects/dynamic_ab/dab.py i /home/dcslab/bhyoo/projects/dynamic_ab/script5.json",
 			"bound_cores": "0-7",
 			"cpu_freq": 2.1,
-			"parser": "tomcat"
+			"parser": "ssh"
 		}
 	],
 	"perf": {

--- a/hybrid_iso/config.template.json
+++ b/hybrid_iso/config.template.json
@@ -31,6 +31,18 @@
 			"cycle_limit": 100,
 			"cycle_limit_time_slice": 20000,
 			"cpu_freq": 2.1
+		},
+		{
+			"ssh": {
+				"host": "bc2",
+				"username": "dcslab",
+				"password": "dcs%%*#",
+				"working_directory": "/home/dcslab/bhyoo/projects/dynamic_ab",
+				"command": ". ./venv/bin/activate; ./dab.py i script5.json"
+			},
+			"bound_cores": "0-7",
+			"cpu_freq": 2.1,
+			"parser": "tomcat"
 		}
 	],
 	"perf": {

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+asyncssh==1.17.1
 aio-pika==5.6.0
 aiofile_linux
 coloredlogs==10.0


### PR DESCRIPTION
Add a new type of `BaseBenchmark` that capable to launch command remotely via ssh (using [asyncssh](https://pypi.org/project/asyncssh/)).